### PR TITLE
Fix up some fix32 math

### DIFF
--- a/src/z8lua/fix32.h
+++ b/src/z8lua/fix32.h
@@ -16,13 +16,16 @@
 #include <stdint.h> // int32_t, int64_t, …
 #include <math.h> // pow()
 
-extern long long llabs(long long n);
-
 typedef int32_t fix32_t;
+#define FIX32_MAX INT32_MAX
+#define FIX32_MIN INT32_MIN
 
+static inline fix32_t fix32_value(int16_t i, uint16_t f);
 static inline fix32_t fix32_from_string(const char* s, char** endptr);
 static inline fix32_t fix32_from_double(double d);
 static inline double fix32_to_double(fix32_t x);
+static inline fix32_t fix32_from_int(int i);
+static inline int fix32_to_int(fix32_t x);
 static inline fix32_t fix32_from_int8(int8_t x);
 static inline fix32_t fix32_from_uint8(uint8_t x);
 static inline fix32_t fix32_from_int16(int16_t x);
@@ -81,6 +84,11 @@ static inline fix32_t fix32_lshr(fix32_t x, int y);
 static inline fix32_t fix32_rotl(fix32_t x, int y);
 static inline fix32_t fix32_rotr(fix32_t x, int y);
 
+static inline fix32_t fix32_value(int16_t i, uint16_t f)
+{
+    return (fix32_t)(((uint32_t)i << 16) | ((uint32_t)f & 0xffffu));
+}
+
 static inline fix32_t fix32_from_string(const char* s, char** endptr)
 {
     return fix32_from_double(strtod(s, endptr));
@@ -92,6 +100,14 @@ static inline fix32_t fix32_from_double(double d) {
 
 static inline double fix32_to_double(fix32_t x) {
     return (double)x * (1.0 / 65536.0);
+}
+
+static inline fix32_t fix32_from_int(int i) {
+    return (int)(i << 16);
+}
+
+static inline int fix32_to_int(fix32_t x) {
+    return (int)(x >> 16);
 }
 
 // Conversions up to int16_t are safe.
@@ -244,7 +260,7 @@ static inline fix32_t fix32_xor(fix32_t a, fix32_t b) {
 }
 
 static inline fix32_t fix32_mul(fix32_t a, fix32_t b) {
-    return (int32_t)((int64_t)a * b >> 16);
+    return (int32_t)((int64_t)a * (b >> 16));
 }
 
 static inline fix32_t fix32_div(fix32_t a, fix32_t b) {
@@ -321,7 +337,7 @@ static inline fix32_t fix32_mod_assign(fix32_t *a, fix32_t b) {
 
 // PICO-8 0.2.3 changelog: abs(0x8000) should be 0x7fff.ffff
 static inline fix32_t fix32_abs(fix32_t a) {
-    if (a == 0x8000) {
+    if (a == 0x80000000) {
         return 0x7fffffff;
     }
     return a >= 0 ? a : a << 1 == 0 ? fix32_not(a) : fix32_neg(a);

--- a/src/z8lua/fix32.h
+++ b/src/z8lua/fix32.h
@@ -260,7 +260,7 @@ static inline fix32_t fix32_xor(fix32_t a, fix32_t b) {
 }
 
 static inline fix32_t fix32_mul(fix32_t a, fix32_t b) {
-    return (int32_t)((int64_t)a * (b >> 16));
+    return (int32_t)(((int64_t)a * b) >> 16);
 }
 
 static inline fix32_t fix32_div(fix32_t a, fix32_t b) {

--- a/src/z8lua/llimits.h
+++ b/src/z8lua/llimits.h
@@ -93,7 +93,7 @@ typedef LUAI_UACNUMBER l_uacNumber;
 #define cast(t, exp)	((t)(exp))
 
 #define cast_byte(i)	cast(lu_byte, (i))
-#define cast_num(i)	cast(lua_Number, (i))
+#define cast_num(i)	cast(lua_Number, fix32_from_int32((i)))
 #define cast_int(i)	cast(int, (i))
 #define cast_uchar(i)	cast(unsigned char, (i))
 

--- a/src/z8lua/lobject.c
+++ b/src/z8lua/lobject.c
@@ -174,7 +174,7 @@ static lua_Number readany (const char **s, lua_Number r, int *count, int base, i
     if (max > 0) {
       int d = luaO_hexavalue(cast_uchar(**s));
       if (d >= base) break;
-      r = r * cast_num(base) + cast_num(d);
+      r = fix32_add(fix32_mul(r, cast_num(base)), cast_num(d));
       (*count)++;
     }
   }
@@ -199,7 +199,7 @@ static lua_Number lua_Number_from_bits(uint64_t bits) {
 static lua_Number lua_strany2number (const char *s, char **endptr, int base) {
   uint64_t r_bits;
   uint64_t f_bits;
-  lua_Number r = 0.0, f = 0.0;
+  lua_Number r = 0, f = 0;
   int e = 0, i = 0;
   int neg = 0;  /* 1 if number is negative */
   *endptr = cast(char *, s);  /* nothing is valid yet */
@@ -207,15 +207,15 @@ static lua_Number lua_strany2number (const char *s, char **endptr, int base) {
   neg = isneg(&s);  /* check sign */
   if (*s != '0' || (base == 2 && *(s + 1) != 'b' && *(s + 1) != 'B')
                 || (base == 16 && *(s + 1) != 'x' && *(s + 1) != 'X'))
-    return 0.0;  /* invalid format (no '0b' or '0x') */
+    return 0;  /* invalid format (no '0b' or '0x') */
   s += 2;  /* skip '0x' or '0b' */
-  r = readany(&s, r, &i, base, INT_MAX);  /* read integer part */
+  r = readany(&s, r, &i, base, FIX32_MAX);  /* read integer part */
   if (*s == '.') {
     s++;  /* skip dot */
     f = readany(&s, f, &e, base, base == 2 ? 16 : 4);  /* read fractional part */
   }
   if (i == 0 && e == 0)
-    return 0.0;  /* invalid format (no digit) */
+    return 0;  /* invalid format (no digit) */
   *endptr = cast(char *, s);  /* valid up to here */
   r_bits = lua_Number_to_bits(r);
   f_bits = lua_Number_to_bits(f);
@@ -230,7 +230,7 @@ int luaO_str2d (const char *s, size_t len, lua_Number *result) {
   if (strpbrk(s, "nN"))  /* reject 'inf' and 'nan' */
     return 0;
   else if (strpbrk(s, "xX"))  /* hexa? */
-    *result = lua_strany2number(s, &endptr, 16);
+      *result = lua_strany2number(s, &endptr, 16);
   else if (strpbrk(s, "bB"))  /* binary? */
     *result = lua_strany2number(s, &endptr, 2);
   else

--- a/src/z8lua/lpico8lib.c
+++ b/src/z8lua/lpico8lib.c
@@ -151,27 +151,27 @@ static int pico8_bnot(lua_State *l) {
 }
 
 static int pico8_shl(lua_State *l) {
-    lua_pushnumber(l, fix32_shl(lua_tonumber(l, 1), (int)lua_tonumber(l, 2)));
+    lua_pushnumber(l, fix32_shl(lua_tonumber(l, 1), fix32_to_int(lua_tonumber(l, 2))));
     return 1;
 }
 
 static int pico8_lshr(lua_State *l) {
-    lua_pushnumber(l, fix32_lshr(lua_tonumber(l, 1), (int)lua_tonumber(l, 2)));
+    lua_pushnumber(l, fix32_lshr(lua_tonumber(l, 1), fix32_to_int(lua_tonumber(l, 2))));
     return 1;
 }
 
 static int pico8_shr(lua_State *l) {
-    lua_pushnumber(l, fix32_shr(lua_tonumber(l, 1), (int)lua_tonumber(l, 2)));
+    lua_pushnumber(l, fix32_shr(lua_tonumber(l, 1), fix32_to_int(lua_tonumber(l, 2))));
     return 1;
 }
 
 static int pico8_rotl(lua_State *l) {
-    lua_pushnumber(l, fix32_rotl(lua_tonumber(l, 1), (int)lua_tonumber(l, 2)));
+    lua_pushnumber(l, fix32_rotl(lua_tonumber(l, 1), fix32_to_int(lua_tonumber(l, 2))));
     return 1;
 }
 
 static int pico8_rotr(lua_State *l) {
-    lua_pushnumber(l, fix32_rotr(lua_tonumber(l, 1), (int)lua_tonumber(l, 2)));
+    lua_pushnumber(l, fix32_rotr(lua_tonumber(l, 1), fix32_to_int(lua_tonumber(l, 2))));
     return 1;
 }
 

--- a/src/z8lua/luaconf.h
+++ b/src/z8lua/luaconf.h
@@ -433,21 +433,21 @@
 /* the following operations need the math library */
 #if defined(lobject_c) || defined(lvm_c)
 #include <math.h>
-#define luai_nummod(L,a,b)	((a) - l_mathop(floor)((a)/(b))*(b))
-#define luai_numpow(L,a,b)	(l_mathop(pow)(a,b))
+#define luai_nummod(L,a,b)	((a) - l_mathop(fix32_floor)((a)/(b))*(b))
+#define luai_numpow(L,a,b)	(l_mathop(fix32_pow)((a),(b)))
 #endif
 
 /* these are quite standard operations */
 #if defined(LUA_CORE)
-#define luai_numadd(L,a,b)	((a)+(b))
-#define luai_numsub(L,a,b)	((a)-(b))
-#define luai_nummul(L,a,b)	((a)*(b))
-#define luai_numdiv(L,a,b)	((a)/(b))
-#define luai_numunm(L,a)	(-(a))
-#define luai_numeq(a,b)		((a)==(b))
-#define luai_numlt(L,a,b)	((a)<(b))
-#define luai_numle(L,a,b)	((a)<=(b))
-#define luai_numisnan(L,a)	(!luai_numeq((a), (a)))
+#define luai_numadd(L,a,b)	(l_mathop(fix32_add)((a),(b)))
+#define luai_numsub(L,a,b)	(l_mathop(fix32_sub)((a),(b)))
+#define luai_nummul(L,a,b)	(l_mathop(fix32_mul)((a),(b)))
+#define luai_numdiv(L,a,b)	(l_mathop(fix32_div)((a),(b)))
+#define luai_numunm(L,a)	(l_mathop(fix32_neg)((a)))
+#define luai_numeq(a,b)		(l_mathop(fix32_eq)((a),(b)))
+#define luai_numlt(L,a,b)	(l_mathop(fix32_lt)((a),(b)))
+#define luai_numle(L,a,b)	(l_mathop(fix32_le)((a),(b)))
+#define luai_numisnan(L,a)	!!0
 #endif
 
 

--- a/tests/tests.p8
+++ b/tests/tests.p8
@@ -11,12 +11,15 @@ function assert_equal(actual, expected, test_name)
 end
 
 function run_tests()
-    assert_equal(abs(5),               5, "abs(5)")
-    assert_equal(abs(-5),              5, "abs(-5)")
-    assert_equal(abs(0),               0, "abs(0)")
-    assert_equal(abs(12345),       12345, "abs(12345)")
-    assert_equal(abs(-12345),      12345, "abs(-12345)")
-    assert_equal(abs(0x8000), 0x7fffffff, "abs(0x8000)")
+    local epsilon = 0.0000152587890625
+    local lt_one = 1.0 - epsilon
+
+    assert_equal(abs(5),                    5, "abs(5)")
+    assert_equal(abs(-5),                   5, "abs(-5)")
+    assert_equal(abs(0),                    0, "abs(0)")
+    assert_equal(abs(12345),            12345, "abs(12345)")
+    assert_equal(abs(-12345),           12345, "abs(-12345)")
+    assert_equal(abs(0x8000), 0x7fff + lt_one, "abs(0x8000)")
 
     assert_equal(atan2(1, 0),    0,     "atan2(1, 0)")
     assert_equal(atan2(1, 1),    0.875, "atan2(1, 1)")
@@ -29,6 +32,8 @@ function run_tests()
     assert_equal(atan2(0, 0),    0.25,  "atan2(0, 0)")
     assert_equal(atan2(99, 99),  0.875, "atan2(99, 99)")
 
+    -- These tests aren't right. The results of the functions aren't raw fixed
+    -- point integers from the perspective of this Lua code.
     assert_equal(cos(0),     0x00010000, "cos(0)")
     assert_equal(cos(0.125), 0x0000b505, "cos(0.125)")
     assert_equal(cos(0.25),  0x00000000, "cos(0.25)")


### PR DESCRIPTION
I've applied fixes to some of the fix32 math. Not all tests yet pass, though some aren't even correct; check tests.p8 for a note about their incorrectness. I did correct one of the tests though, the `abs(0x8000)` one.